### PR TITLE
Addon prioritizing

### DIFF
--- a/bukkitgui2/AddOn/AddonManager.cs
+++ b/bukkitgui2/AddOn/AddonManager.cs
@@ -1,4 +1,4 @@
-﻿// AddonManager.cs in bukkitgui2/bukkitgui2
+// AddonManager.cs in bukkitgui2/bukkitgui2
 // Created 2014/05/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -233,28 +233,28 @@ namespace Net.Bertware.Bukkitgui2.AddOn
 		/// <returns></returns>
 		private static Dictionary<string, Type> GetAvailableAddons()
 		{
-            List<Type> unsortedAddons = new List<Type>();
+			List<Type> unsortedAddons = new List<Type>();
 			Dictionary<string, Type> addons = new Dictionary<string, Type>();
-            // Get unsorted list of all addons
+			// Get unsorted list of all addons
 			foreach (
 				Type addon in DynamicModuleLoader.ListClassesRecursiveOfType<IAddon>("Net.Bertware.Bukkitgui2.AddOn"))
 			{
-                unsortedAddons.Add(addon);
+				unsortedAddons.Add(addon);
 			}
 
-            unsortedAddons.Sort((t1, t2) =>
-            {
-                IAddon a1 = (IAddon)Activator.CreateInstance(t1);
-                IAddon a2 = (IAddon)Activator.CreateInstance(t2);
-                return a2.Priority.CompareTo(a1.Priority);
-            });
+			unsortedAddons.Sort((t1, t2) =>
+			{
+				IAddon a1 = (IAddon)Activator.CreateInstance(t1);
+				IAddon a2 = (IAddon)Activator.CreateInstance(t2);
+				return a2.Priority.CompareTo(a1.Priority);
+			});
 
-            foreach (Type addon in unsortedAddons)
-            {
-                if (!addons.ContainsKey(addon.Name)) addons.Add(addon.Name, addon);
-            }
-            
-            Logger.Log(LogLevel.Info, "AddonManager", "Found " + addons.Count + " available addons");
+			foreach (Type addon in unsortedAddons)
+			{
+				if (!addons.ContainsKey(addon.Name)) addons.Add(addon.Name, addon);
+			}
+			
+			Logger.Log(LogLevel.Info, "AddonManager", "Found " + addons.Count + " available addons");
 			return addons;
 		}
 	}

--- a/bukkitgui2/AddOn/AddonManager.cs
+++ b/bukkitgui2/AddOn/AddonManager.cs
@@ -233,13 +233,28 @@ namespace Net.Bertware.Bukkitgui2.AddOn
 		/// <returns></returns>
 		private static Dictionary<string, Type> GetAvailableAddons()
 		{
+            List<Type> unsortedAddons = new List<Type>();
 			Dictionary<string, Type> addons = new Dictionary<string, Type>();
+            // Get unsorted list of all addons
 			foreach (
 				Type addon in DynamicModuleLoader.ListClassesRecursiveOfType<IAddon>("Net.Bertware.Bukkitgui2.AddOn"))
 			{
-				if (!addons.ContainsKey(addon.Name)) addons.Add(addon.Name, addon);
+                unsortedAddons.Add(addon);
 			}
-			Logger.Log(LogLevel.Info, "AddonManager", "Found " + addons.Count + " available addons");
+
+            unsortedAddons.Sort((t1, t2) =>
+            {
+                IAddon a1 = (IAddon)Activator.CreateInstance(t1);
+                IAddon a2 = (IAddon)Activator.CreateInstance(t2);
+                return a2.Priority.CompareTo(a1.Priority);
+            });
+
+            foreach (Type addon in unsortedAddons)
+            {
+                if (!addons.ContainsKey(addon.Name)) addons.Add(addon.Name, addon);
+            }
+            
+            Logger.Log(LogLevel.Info, "AddonManager", "Found " + addons.Count + " available addons");
 			return addons;
 		}
 	}

--- a/bukkitgui2/AddOn/Backup/Backup.cs
+++ b/bukkitgui2/AddOn/Backup/Backup.cs
@@ -1,4 +1,4 @@
-﻿// Backup.cs in bukkitgui2/bukkitgui2
+// Backup.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // Last edited at 2015/08/01 12:56
 // ©Bertware, visit http://bertware.net
@@ -24,7 +24,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 		{
 			Reference = this;
 			Name = "Backup";
-            Priority = 0;
+			Priority = 0;
 			HasTab = true;
 			TabPage = new BackupTab();
 			HasConfig = false;
@@ -36,15 +36,15 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 		/// </summary>
 		public string Name { get; private set; }
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority { get; private set; }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab { get; private set; }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab { get; private set; }
 
 		/// <summary>
 		///     True if this addon has a config field
@@ -105,7 +105,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 			get { return Backups != null; }
 		}
 
-        public void LoadAllBackups()
+		public void LoadAllBackups()
 		{
 			try
 			{

--- a/bukkitgui2/AddOn/Backup/Backup.cs
+++ b/bukkitgui2/AddOn/Backup/Backup.cs
@@ -24,6 +24,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 		{
 			Reference = this;
 			Name = "Backup";
+            Priority = 0;
 			HasTab = true;
 			TabPage = new BackupTab();
 			HasConfig = false;
@@ -35,10 +36,15 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 		/// </summary>
 		public string Name { get; private set; }
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab { get; private set; }
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority { get; private set; }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab { get; private set; }
 
 		/// <summary>
 		///     True if this addon has a config field
@@ -99,8 +105,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Backup
 			get { return Backups != null; }
 		}
 
-
-		public void LoadAllBackups()
+        public void LoadAllBackups()
 		{
 			try
 			{

--- a/bukkitgui2/AddOn/Console/Console.cs
+++ b/bukkitgui2/AddOn/Console/Console.cs
@@ -21,10 +21,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Console
 			get { return "Console"; }
 		}
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Console/Console.cs
+++ b/bukkitgui2/AddOn/Console/Console.cs
@@ -1,4 +1,4 @@
-﻿// Console.cs in bukkitgui2/bukkitgui2
+// Console.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -21,18 +21,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Console
 			get { return "Console"; }
 		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Editor/Editor.cs
+++ b/bukkitgui2/AddOn/Editor/Editor.cs
@@ -22,6 +22,14 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Editor
         }
 
         /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
         ///     True if this addon has a tab page
         /// </summary>
         public bool HasTab

--- a/bukkitgui2/AddOn/Editor/Editor.cs
+++ b/bukkitgui2/AddOn/Editor/Editor.cs
@@ -1,4 +1,4 @@
-﻿// Editor.cs in bukkitgui2/bukkitgui2
+// Editor.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -11,65 +11,65 @@ using MetroFramework.Controls;
 
 namespace Net.Bertware.Bukkitgui2.AddOn.Editor
 {
-    internal class Editor : IAddon
-    {
-        /// <summary>
-        ///     The addon name, ideally this name is the same as used in the tabpage
-        /// </summary>
-        public string Name
-        {
-            get { return "Editor"; }
-        }
+	internal class Editor : IAddon
+	{
+		/// <summary>
+		///     The addon name, ideally this name is the same as used in the tabpage
+		/// </summary>
+		public string Name
+		{
+			get { return "Editor"; }
+		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
-        {
-            get { return true; }
-        }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
+		{
+			get { return true; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a config field
-        /// </summary>
-        public bool HasConfig
-        {
-            get { return false; }
-        }
+		/// <summary>
+		///     True if this addon has a config field
+		/// </summary>
+		public bool HasConfig
+		{
+			get { return false; }
+		}
 
-        /// <summary>
-        ///     Initialize all functions and the tabcontrol
-        /// </summary>
-        public void Initialize()
-        {
-            TabPage = new EditorTab {Text = Name, ParentAddon = this};
+		/// <summary>
+		///     Initialize all functions and the tabcontrol
+		/// </summary>
+		public void Initialize()
+		{
+			TabPage = new EditorTab {Text = Name, ParentAddon = this};
 	        ConfigPage = null;
-        }
+		}
 
-        public void Dispose()
-        {
-            // nothing to do
-        }
+		public void Dispose()
+		{
+			// nothing to do
+		}
 
-        /// <summary>
-        ///     The tab control for this addon
-        /// </summary>
-        /// <returns>Returns the tabpage</returns>
-        public MetroUserControl TabPage { get; private set; }
+		/// <summary>
+		///     The tab control for this addon
+		/// </summary>
+		/// <returns>Returns the tabpage</returns>
+		public MetroUserControl TabPage { get; private set; }
 
-        public MetroUserControl ConfigPage { get; private set; }
+		public MetroUserControl ConfigPage { get; private set; }
 
-        public bool CanDisable
-        {
-            get { return true; }
-        }
-    }
+		public bool CanDisable
+		{
+			get { return true; }
+		}
+	}
 }

--- a/bukkitgui2/AddOn/Forwarder/Forwarder.cs
+++ b/bukkitgui2/AddOn/Forwarder/Forwarder.cs
@@ -16,6 +16,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Forwarder
         public Forwarder()
         {
             Name = "Forwarder (experimental)";
+            Priority = 0;
             HasTab = true;
             HasConfig = false;
 	        ConfigPage = null;
@@ -25,6 +26,11 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Forwarder
         ///     The addon name, ideally this name is the same as used in the tabpage
         /// </summary>
         public string Name { get; private set; }
+
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority { get; private set; }
 
         /// <summary>
         ///     True if this addon has a tab page

--- a/bukkitgui2/AddOn/Forwarder/Forwarder.cs
+++ b/bukkitgui2/AddOn/Forwarder/Forwarder.cs
@@ -1,4 +1,4 @@
-﻿// Forwarder.cs in bukkitgui2/bukkitgui2
+// Forwarder.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -11,62 +11,62 @@ using MetroFramework.Controls;
 
 namespace Net.Bertware.Bukkitgui2.AddOn.Forwarder
 {
-    internal class Forwarder : IAddon
-    {
-        public Forwarder()
-        {
-            Name = "Forwarder (experimental)";
-            Priority = 0;
-            HasTab = true;
-            HasConfig = false;
+	internal class Forwarder : IAddon
+	{
+		public Forwarder()
+		{
+			Name = "Forwarder (experimental)";
+			Priority = 0;
+			HasTab = true;
+			HasConfig = false;
 	        ConfigPage = null;
-        }
+		}
 
-        /// <summary>
-        ///     The addon name, ideally this name is the same as used in the tabpage
-        /// </summary>
-        public string Name { get; private set; }
+		/// <summary>
+		///     The addon name, ideally this name is the same as used in the tabpage
+		/// </summary>
+		public string Name { get; private set; }
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority { get; private set; }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab { get; private set; }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a config field
-        /// </summary>
-        public bool HasConfig { get; private set; }
+		/// <summary>
+		///     True if this addon has a config field
+		/// </summary>
+		public bool HasConfig { get; private set; }
 
 
-        /// <summary>
-        ///     Initialize all functions and the tabcontrol
-        /// </summary>
-        public void Initialize()
-        {
-            TabPage = new ForwarderTab {Text = Name, ParentAddon = this};
-        }
+		/// <summary>
+		///     Initialize all functions and the tabcontrol
+		/// </summary>
+		public void Initialize()
+		{
+			TabPage = new ForwarderTab {Text = Name, ParentAddon = this};
+		}
 
-        public void Dispose()
-        {
-            // nothing to do
-        }
+		public void Dispose()
+		{
+			// nothing to do
+		}
 
-        /// <summary>
-        ///     The tab control for this addon
-        /// </summary>
-        /// <returns>Returns the tabpage</returns>
-        public MetroUserControl TabPage { get; private set; }
+		/// <summary>
+		///     The tab control for this addon
+		/// </summary>
+		/// <returns>Returns the tabpage</returns>
+		public MetroUserControl TabPage { get; private set; }
 
-        public MetroUserControl ConfigPage { get; private set; }
+		public MetroUserControl ConfigPage { get; private set; }
 
-        public bool CanDisable
-        {
-            get { return true; }
-        }
-    }
+		public bool CanDisable
+		{
+			get { return true; }
+		}
+	}
 }

--- a/bukkitgui2/AddOn/IAddon.cs
+++ b/bukkitgui2/AddOn/IAddon.cs
@@ -19,6 +19,11 @@ namespace Net.Bertware.Bukkitgui2.AddOn
 		/// </summary>
 		string Name { get; }
 
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        int Priority { get; }
+
 		/// <summary>
 		///     True if this addon has a tabpage
 		/// </summary>

--- a/bukkitgui2/AddOn/IAddon.cs
+++ b/bukkitgui2/AddOn/IAddon.cs
@@ -1,4 +1,4 @@
-﻿// IAddon.cs in bukkitgui2/bukkitgui2
+// IAddon.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/30
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -19,10 +19,10 @@ namespace Net.Bertware.Bukkitgui2.AddOn
 		/// </summary>
 		string Name { get; }
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        int Priority { get; }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		int Priority { get; }
 
 		/// <summary>
 		///     True if this addon has a tabpage

--- a/bukkitgui2/AddOn/Issues/Issues.cs
+++ b/bukkitgui2/AddOn/Issues/Issues.cs
@@ -16,6 +16,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Issues
 		public Issues()
 		{
 			Name = "Issues";
+            Priority = 0;
 			HasTab = true;
 			TabPage = new IssuesTab();
 			HasConfig = false;
@@ -27,10 +28,15 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Issues
 		/// </summary>
 		public string Name { get; private set; }
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab { get; private set; }
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority { get; private set; }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab { get; private set; }
 
 		/// <summary>
 		///     True if this addon has a config field

--- a/bukkitgui2/AddOn/Issues/Issues.cs
+++ b/bukkitgui2/AddOn/Issues/Issues.cs
@@ -1,4 +1,4 @@
-﻿// Issues.cs in bukkitgui2/bukkitgui2
+// Issues.cs in bukkitgui2/bukkitgui2
 // Created 2014/08/31
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -16,7 +16,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Issues
 		public Issues()
 		{
 			Name = "Issues";
-            Priority = 0;
+			Priority = 0;
 			HasTab = true;
 			TabPage = new IssuesTab();
 			HasConfig = false;
@@ -28,15 +28,15 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Issues
 		/// </summary>
 		public string Name { get; private set; }
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority { get; private set; }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab { get; private set; }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab { get; private set; }
 
 		/// <summary>
 		///     True if this addon has a config field

--- a/bukkitgui2/AddOn/Notifications/Notifications.cs
+++ b/bukkitgui2/AddOn/Notifications/Notifications.cs
@@ -34,7 +34,12 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Notifications
 			get { return "Notifications"; }
 		}
 
-		public bool HasTab
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        public bool HasTab
 		{
 			get { return false; }
 		}

--- a/bukkitgui2/AddOn/Notifications/Notifications.cs
+++ b/bukkitgui2/AddOn/Notifications/Notifications.cs
@@ -1,4 +1,4 @@
-﻿// Notifications.cs in bukkitgui2/bukkitgui2
+// Notifications.cs in bukkitgui2/bukkitgui2
 // Created 2014/06/21
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -34,12 +34,12 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Notifications
 			get { return "Notifications"; }
 		}
 
-        public int Priority
-        {
-            get { return 0; }
-        }
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        public bool HasTab
+		public bool HasTab
 		{
 			get { return false; }
 		}

--- a/bukkitgui2/AddOn/Playerlist/PlayerList.cs
+++ b/bukkitgui2/AddOn/Playerlist/PlayerList.cs
@@ -32,10 +32,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.PlayerList
 			get { return "Players"; }
 		}
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Playerlist/PlayerList.cs
+++ b/bukkitgui2/AddOn/Playerlist/PlayerList.cs
@@ -1,4 +1,4 @@
-﻿// PlayerList.cs in bukkitgui2/bukkitgui2
+// PlayerList.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -32,18 +32,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.PlayerList
 			get { return "Players"; }
 		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Plugins/Plugins.cs
+++ b/bukkitgui2/AddOn/Plugins/Plugins.cs
@@ -1,4 +1,4 @@
-﻿// Plugins.cs in bukkitgui2/bukkitgui2
+// Plugins.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -22,18 +22,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Plugins
 			get { return "Plugins"; }
 		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Plugins/Plugins.cs
+++ b/bukkitgui2/AddOn/Plugins/Plugins.cs
@@ -22,10 +22,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Plugins
 			get { return "Plugins"; }
 		}
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Settings/Settings.cs
+++ b/bukkitgui2/AddOn/Settings/Settings.cs
@@ -61,7 +61,7 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Settings
         /// </summary>
         public int Priority
         {
-            get { return 10; }
+            get { return -10; }
         }
 
         /// <summary>

--- a/bukkitgui2/AddOn/Settings/Settings.cs
+++ b/bukkitgui2/AddOn/Settings/Settings.cs
@@ -1,4 +1,4 @@
-﻿// Settings.cs in bukkitgui2/bukkitgui2
+// Settings.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -11,84 +11,84 @@ using MetroFramework.Controls;
 
 namespace Net.Bertware.Bukkitgui2.AddOn.Settings
 {
-    internal class Settings : IAddon
-    {
-        public Settings()
-        {
-            TabPage = null;
+	internal class Settings : IAddon
+	{
+		public Settings()
+		{
+			TabPage = null;
 	        ConfigPage = null;
-        }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
-        {
-            get { return true; }
-        }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
+		{
+			get { return true; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a config field
-        /// </summary>
-        public bool HasConfig
-        {
-            get { return false; }
-        }
+		/// <summary>
+		///     True if this addon has a config field
+		/// </summary>
+		public bool HasConfig
+		{
+			get { return false; }
+		}
 
-        public void Dispose()
-        {
-            // nothing to do
-        }
+		public void Dispose()
+		{
+			// nothing to do
+		}
 
-        /// <summary>
-        ///     The tab control for this addon
-        /// </summary>
-        /// <returns>Returns the tabpage</returns>
-        public MetroUserControl TabPage { get; private set; }
+		/// <summary>
+		///     The tab control for this addon
+		/// </summary>
+		/// <returns>Returns the tabpage</returns>
+		public MetroUserControl TabPage { get; private set; }
 
-        public MetroUserControl ConfigPage { get; private set; }
+		public MetroUserControl ConfigPage { get; private set; }
 
-        /// <summary>
-        ///     The addon name, ideally this name is the same as used in the tabpage
-        /// </summary>
-        public string Name
-        {
-            get { return "Settings"; }
-        }
+		/// <summary>
+		///     The addon name, ideally this name is the same as used in the tabpage
+		/// </summary>
+		public string Name
+		{
+			get { return "Settings"; }
+		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return -10; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return -10; }
+		}
 
-        /// <summary>
-        ///     Initialize all functions and the tabcontrol
-        /// </summary>
-        public void Initialize()
-        {
-            if (TabPage == null) TabPage = new SettingsTab {Text = Name, ParentAddon = this};
-            ((SettingsTab) TabPage).Initialize();
-        }
+		/// <summary>
+		///     Initialize all functions and the tabcontrol
+		/// </summary>
+		public void Initialize()
+		{
+			if (TabPage == null) TabPage = new SettingsTab {Text = Name, ParentAddon = this};
+			((SettingsTab) TabPage).Initialize();
+		}
 
-        /// <summary>
-        ///     Remove the settings control for a given addon
-        /// </summary>
-        /// <param name="addon"></param>
-        /// <remarks>Reloading addons is highly discouraged! Only use if no other way is possible</remarks>
-        public void RemoveAddonSettings(IAddon addon)
-        {
-        }
+		/// <summary>
+		///     Remove the settings control for a given addon
+		/// </summary>
+		/// <param name="addon"></param>
+		/// <remarks>Reloading addons is highly discouraged! Only use if no other way is possible</remarks>
+		public void RemoveAddonSettings(IAddon addon)
+		{
+		}
 
-        /// <summary>
-        ///     Add the settings control for a given addon
-        /// </summary>
-        /// <param name="addon"></param>
-        /// <remarks>Reloading addons is highly discouraged! Only use if no other way is possible</remarks>
-        public void AddAddonSettings(IAddon addon)
-        {
-        }
-    }
+		/// <summary>
+		///     Add the settings control for a given addon
+		/// </summary>
+		/// <param name="addon"></param>
+		/// <remarks>Reloading addons is highly discouraged! Only use if no other way is possible</remarks>
+		public void AddAddonSettings(IAddon addon)
+		{
+		}
+	}
 }

--- a/bukkitgui2/AddOn/Settings/Settings.cs
+++ b/bukkitgui2/AddOn/Settings/Settings.cs
@@ -57,6 +57,14 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Settings
         }
 
         /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 10; }
+        }
+
+        /// <summary>
         ///     Initialize all functions and the tabcontrol
         /// </summary>
         public void Initialize()

--- a/bukkitgui2/AddOn/Starter/Starter.cs
+++ b/bukkitgui2/AddOn/Starter/Starter.cs
@@ -1,4 +1,4 @@
-﻿// Starter.cs in bukkitgui2/bukkitgui2
+// Starter.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -30,18 +30,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Starter
 			get { return "Starter"; }
 		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Starter/Starter.cs
+++ b/bukkitgui2/AddOn/Starter/Starter.cs
@@ -30,10 +30,18 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Starter
 			get { return "Starter"; }
 		}
 
-		/// <summary>
-		///     True if this addon has a tab page
-		/// </summary>
-		public bool HasTab
+        /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        ///     True if this addon has a tab page
+        /// </summary>
+        public bool HasTab
 		{
 			get { return true; }
 		}

--- a/bukkitgui2/AddOn/Tasker/Tasker.cs
+++ b/bukkitgui2/AddOn/Tasker/Tasker.cs
@@ -42,6 +42,11 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Tasker
         public string Name { get; private set; }
 
         /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority { get; private set; }
+
+        /// <summary>
         ///     True if this addon has a tab page
         /// </summary>
         public bool HasTab { get; private set; }

--- a/bukkitgui2/AddOn/Tasker/Tasker.cs
+++ b/bukkitgui2/AddOn/Tasker/Tasker.cs
@@ -1,4 +1,4 @@
-﻿// Tasker.cs in bukkitgui2/bukkitgui2
+// Tasker.cs in bukkitgui2/bukkitgui2
 // Created 2014/01/17
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -18,64 +18,64 @@ using Net.Bertware.Bukkitgui2.Core.Logging;
 
 namespace Net.Bertware.Bukkitgui2.AddOn.Tasker
 {
-    public delegate void TaskerEventArgs();
+	public delegate void TaskerEventArgs();
 
-    public class Tasker : IAddon
-    {
-        public event EventHandler TaskListAltered;
-        public event EventHandler TaskExecuted;
-        public static Tasker Reference { get; private set; }
-        public static Dictionary<string, Task> Tasks;
-        private static readonly string _Configfile = Fl.SafeLocation(RequestFile.Config) + "tasklist";
+	public class Tasker : IAddon
+	{
+		public event EventHandler TaskListAltered;
+		public event EventHandler TaskExecuted;
+		public static Tasker Reference { get; private set; }
+		public static Dictionary<string, Task> Tasks;
+		private static readonly string _Configfile = Fl.SafeLocation(RequestFile.Config) + "tasklist";
 
-        public Tasker()
-        {
-            Reference = this;
-            Name = "Tasker";
-            HasTab = true;
-            HasConfig = false;
-        }
+		public Tasker()
+		{
+			Reference = this;
+			Name = "Tasker";
+			HasTab = true;
+			HasConfig = false;
+		}
 
-        /// <summary>
-        ///     The addon name, ideally this name is the same as used in the tabpage
-        /// </summary>
-        public string Name { get; private set; }
+		/// <summary>
+		///     The addon name, ideally this name is the same as used in the tabpage
+		/// </summary>
+		public string Name { get; private set; }
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority { get; private set; }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab { get; private set; }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab { get; private set; }
 
-        /// <summary>
-        ///     True if this addon has a config field
-        /// </summary>
-        public bool HasConfig { get; private set; }
+		/// <summary>
+		///     True if this addon has a config field
+		/// </summary>
+		public bool HasConfig { get; private set; }
 
-        /// <summary>
-        ///     Initialize all functions and the tabcontrol
-        /// </summary>
-        public void Initialize()
-        {
-            LoadTasks();
-            TabPage = new TaskerTab {Text = Name, ParentAddon = this};
-            ConfigPage = null;
-        }
+		/// <summary>
+		///     Initialize all functions and the tabcontrol
+		/// </summary>
+		public void Initialize()
+		{
+			LoadTasks();
+			TabPage = new TaskerTab {Text = Name, ParentAddon = this};
+			ConfigPage = null;
+		}
 
-        private void LoadTasks()
-        {
-            Logger.Log(LogLevel.Info, "Tasker", "Loading tasks...", _Configfile);
+		private void LoadTasks()
+		{
+			Logger.Log(LogLevel.Info, "Tasker", "Loading tasks...", _Configfile);
 
-            Tasks = new Dictionary<string, Task>();
-            if (!File.Exists(_Configfile)) File.Create(_Configfile).Close();
-            using (StreamReader sr = File.OpenText(_Configfile))
-            {
-                while (!sr.EndOfStream)
-                {
+			Tasks = new Dictionary<string, Task>();
+			if (!File.Exists(_Configfile)) File.Create(_Configfile).Close();
+			using (StreamReader sr = File.OpenText(_Configfile))
+			{
+				while (!sr.EndOfStream)
+				{
 	                try
 	                {
 		                Task t = new Task(sr.ReadLine());
@@ -87,60 +87,60 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Tasker
 						Logger.Log(LogLevel.Warning, "Tasker", "Failed to parse task", ex.Message);
 	                }
 
-                }
-            }
-            Logger.Log(LogLevel.Info, "Tasker", "Loaded all tasks");
-        }
+				}
+			}
+			Logger.Log(LogLevel.Info, "Tasker", "Loaded all tasks");
+		}
 
-        /// <summary>
-        ///     Save (update) a task
-        /// </summary>
-        /// <param name="oldTask"></param>
-        /// <param name="newTask"></param>
-        public void SaveTask(Task oldTask, Task newTask)
-        {
-            DeleteTask(oldTask);
-            AddTask(newTask);
-            // events are fired by delete & add operations
-        }
+		/// <summary>
+		///     Save (update) a task
+		/// </summary>
+		/// <param name="oldTask"></param>
+		/// <param name="newTask"></param>
+		public void SaveTask(Task oldTask, Task newTask)
+		{
+			DeleteTask(oldTask);
+			AddTask(newTask);
+			// events are fired by delete & add operations
+		}
 
-        /// <summary>
-        ///     Add a new task
-        /// </summary>
-        /// <param name="task">the task to add</param>
-        public void AddTask(Task task)
-        {
-            task.Enable();
-            task.TaskExecuted += OnTaskExecuted;
-            if (Tasks != null && !Tasks.ContainsKey(task.Name)) Tasks.Add(task.Name, task);
-            OnTaskListAltered();
-            SaveConfig();
-        }
+		/// <summary>
+		///     Add a new task
+		/// </summary>
+		/// <param name="task">the task to add</param>
+		public void AddTask(Task task)
+		{
+			task.Enable();
+			task.TaskExecuted += OnTaskExecuted;
+			if (Tasks != null && !Tasks.ContainsKey(task.Name)) Tasks.Add(task.Name, task);
+			OnTaskListAltered();
+			SaveConfig();
+		}
 
 
-        /// <summary>
-        ///     Delete a task
-        /// </summary>
-        /// <param name="task">the task to delete</param>
-        public void DeleteTask(Task task)
-        {
+		/// <summary>
+		///     Delete a task
+		/// </summary>
+		/// <param name="task">the task to delete</param>
+		public void DeleteTask(Task task)
+		{
 	        if (task == null) return;
 
-            task.Disable();
-            task.TaskExecuted -= OnTaskExecuted;
+			task.Disable();
+			task.TaskExecuted -= OnTaskExecuted;
 
-            if (Tasks != null && Tasks.ContainsKey(task.Name)) Tasks.Remove(task.Name);
+			if (Tasks != null && Tasks.ContainsKey(task.Name)) Tasks.Remove(task.Name);
 
-            task.Dispose(); // make sure it's removed
+			task.Dispose(); // make sure it's removed
 			OnTaskListAltered();// list changed, invoke event
-            SaveConfig();
-        }
+			SaveConfig();
+		}
 
-        /// <summary>
-        ///     Save all tasks to config file.
-        /// </summary>
-        private static void SaveConfig()
-        {
+		/// <summary>
+		///     Save all tasks to config file.
+		/// </summary>
+		private static void SaveConfig()
+		{
 	        try
 	        {
 
@@ -167,36 +167,36 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Tasker
 			        MessageBoxIcon.Error);
 
 	        }
-        }
+		}
 
-        public void Dispose()
-        {
-            SaveConfig();
-        }
+		public void Dispose()
+		{
+			SaveConfig();
+		}
 
-        /// <summary>
-        ///     The tab control for this addon
-        /// </summary>
-        /// <returns>Returns the tabpage</returns>
-        public MetroUserControl TabPage { get; private set; }
+		/// <summary>
+		///     The tab control for this addon
+		/// </summary>
+		/// <returns>Returns the tabpage</returns>
+		public MetroUserControl TabPage { get; private set; }
 
-        public MetroUserControl ConfigPage { get; private set; }
+		public MetroUserControl ConfigPage { get; private set; }
 
-        public bool CanDisable
-        {
-            get { return true; }
-        }
+		public bool CanDisable
+		{
+			get { return true; }
+		}
 
-        protected virtual void OnTaskExecuted(object sender, EventArgs e)
-        {
-            var handler = TaskExecuted;
-            if (handler != null) handler(sender, e);
-        }
+		protected virtual void OnTaskExecuted(object sender, EventArgs e)
+		{
+			var handler = TaskExecuted;
+			if (handler != null) handler(sender, e);
+		}
 
-        protected virtual void OnTaskListAltered()
-        {
-            var handler = TaskListAltered;
-            if (handler != null) handler(this, EventArgs.Empty);
-        }
-    }
+		protected virtual void OnTaskListAltered()
+		{
+			var handler = TaskListAltered;
+			if (handler != null) handler(this, EventArgs.Empty);
+		}
+	}
 }

--- a/bukkitgui2/AddOn/Updater/Updater.cs
+++ b/bukkitgui2/AddOn/Updater/Updater.cs
@@ -33,6 +33,14 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Updater
         }
 
         /// <summary>
+        ///     The addon priority. Default: 0
+        /// </summary>
+        public int Priority
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
         ///     True if this addon has a tab page
         /// </summary>
         public bool HasTab

--- a/bukkitgui2/AddOn/Updater/Updater.cs
+++ b/bukkitgui2/AddOn/Updater/Updater.cs
@@ -1,4 +1,4 @@
-﻿// Updater.cs in bukkitgui2/bukkitgui2
+// Updater.cs in bukkitgui2/bukkitgui2
 // Created 2014/08/08
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -14,74 +14,74 @@ using Net.Bertware.Get;
 
 namespace Net.Bertware.Bukkitgui2.AddOn.Updater
 {
-    /// <summary>
-    ///     Addon to show updater settings and info
-    /// </summary>
-    internal class Updater : IAddon
-    {
+	/// <summary>
+	///     Addon to show updater settings and info
+	/// </summary>
+	internal class Updater : IAddon
+	{
 	    public Updater()
 	    {
 		    TabPage = null;
 	    }
 
 	    /// <summary>
-        ///     The addon name, ideally this name is the same as used in the tabpage
-        /// </summary>
-        public string Name
-        {
-            get { return "Updater"; }
-        }
+		///     The addon name, ideally this name is the same as used in the tabpage
+		/// </summary>
+		public string Name
+		{
+			get { return "Updater"; }
+		}
 
-        /// <summary>
-        ///     The addon priority. Default: 0
-        /// </summary>
-        public int Priority
-        {
-            get { return 0; }
-        }
+		/// <summary>
+		///     The addon priority. Default: 0
+		/// </summary>
+		public int Priority
+		{
+			get { return 0; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a tab page
-        /// </summary>
-        public bool HasTab
-        {
-            get { return false; }
-        }
+		/// <summary>
+		///     True if this addon has a tab page
+		/// </summary>
+		public bool HasTab
+		{
+			get { return false; }
+		}
 
-        /// <summary>
-        ///     True if this addon has a config field
-        /// </summary>
-        public bool HasConfig
-        {
-            get { return true; }
-        }
+		/// <summary>
+		///     True if this addon has a config field
+		/// </summary>
+		public bool HasConfig
+		{
+			get { return true; }
+		}
 
-        /// <summary>
-        ///     Initialize all functions and the tabcontrol
-        /// </summary>
-        public void Initialize()
-        {
-            ConfigPage = new UpdaterSettings();
-            CheckForUpdates();
-        }
+		/// <summary>
+		///     Initialize all functions and the tabcontrol
+		/// </summary>
+		public void Initialize()
+		{
+			ConfigPage = new UpdaterSettings();
+			CheckForUpdates();
+		}
 
-        public void Dispose()
-        {
-            // nothing to do
-        }
+		public void Dispose()
+		{
+			// nothing to do
+		}
 
-        /// <summary>
-        ///     The tab control for this addon
-        /// </summary>
-        /// <returns>Returns the tabpage</returns>
-        public MetroUserControl TabPage { get; private set; }
+		/// <summary>
+		///     The tab control for this addon
+		/// </summary>
+		/// <returns>Returns the tabpage</returns>
+		public MetroUserControl TabPage { get; private set; }
 
-        public MetroUserControl ConfigPage { get; private set; }
+		public MetroUserControl ConfigPage { get; private set; }
 
-        public bool CanDisable
-        {
-            get { return true; }
-        }
+		public bool CanDisable
+		{
+			get { return true; }
+		}
 
 	    public static void CheckForUpdates()
 	    {
@@ -101,5 +101,5 @@ namespace Net.Bertware.Bukkitgui2.AddOn.Updater
 			    // ignored
 		    }
 	    }
-    }
+	}
 }


### PR DESCRIPTION
Addons will now be sorted based on value of *"Priority"* property inherited from *"IAddon"* interface. Default priority is *"0"*. Addons with value lower than that will be loaded later, with higher - earlier.

Adding this feature fixes settings tab not displaying *"Console"* config page as shown on screenshots bellow:
 - Before
![Before](https://i.imgur.com/aPKxqca.png)
- After
![After](https://i.imgur.com/cwzmZNu.png)